### PR TITLE
gameRoomId is now hashed with big random number

### DIFF
--- a/io-backend/src/main/java/agh/io/iobackend/InitialRunner.java
+++ b/io-backend/src/main/java/agh/io/iobackend/InitialRunner.java
@@ -1,9 +1,11 @@
 package agh.io.iobackend;
 
+import agh.io.iobackend.model.GameRoom;
 import agh.io.iobackend.model.User;
 import agh.io.iobackend.model.Vector;
 import agh.io.iobackend.model.map.GameMap;
 import agh.io.iobackend.model.map.MapStructure;
+import agh.io.iobackend.service.GameRoomService;
 import agh.io.iobackend.service.MapService;
 import agh.io.iobackend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +14,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.List;
 
 @Component
 public class InitialRunner implements CommandLineRunner {
@@ -21,6 +22,9 @@ public class InitialRunner implements CommandLineRunner {
 
     @Autowired
     private MapService mapService;
+
+    @Autowired
+    private GameRoomService gameRoomService;
 
     @Autowired
     UserService userService;
@@ -70,10 +74,15 @@ public class InitialRunner implements CommandLineRunner {
 
         mapService.saveMap(gameMap);
 
+        // Test random GameRoom ID
+        GameRoom gameRoom = new GameRoom(gameMap, 4, 5, user.getUserId());
+        gameRoomService.createGameRoom(gameRoom);
+
         System.out.println("User id: " + user.getUserId());
         System.out.println(user);
         System.out.println("User id: " + user2.getUserId());
         System.out.println(user2);
         System.out.println("Map id: " + gameMap.getMapId());
+        System.out.println("Game Room id: " + gameRoom.getGameRoomID());
     }
 }

--- a/io-backend/src/main/java/agh/io/iobackend/controller/GameController.java
+++ b/io-backend/src/main/java/agh/io/iobackend/controller/GameController.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 
 @CrossOrigin
 @RestController
-@CrossOrigin
 @RequestMapping("/game/")
 public class GameController {
     private static final Logger logger = LoggerFactory.getLogger(GameController.class);

--- a/io-backend/src/main/java/agh/io/iobackend/model/GameRoom.java
+++ b/io-backend/src/main/java/agh/io/iobackend/model/GameRoom.java
@@ -1,6 +1,7 @@
 package agh.io.iobackend.model;
 
 import agh.io.iobackend.model.map.GameMap;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -18,6 +19,10 @@ public class GameRoom {
     @GeneratedValue(
             strategy = GenerationType.SEQUENCE,
             generator = "gameRoom_sequence"
+    )
+    @GenericGenerator(
+            name = "gameRoom_sequence",
+            strategy = "agh.io.iobackend.model.GameRoomSequenceIdGenerator"
     )
     @Column(
             name = "gameRoomID",

--- a/io-backend/src/main/java/agh/io/iobackend/model/GameRoomSequenceIdGenerator.java
+++ b/io-backend/src/main/java/agh/io/iobackend/model/GameRoomSequenceIdGenerator.java
@@ -1,0 +1,21 @@
+package agh.io.iobackend.model;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+
+import java.io.Serializable;
+
+public class GameRoomSequenceIdGenerator extends SequenceStyleGenerator {
+    @Override
+    public Serializable generate(
+            SharedSessionContractImplementor session, Object object
+    ) throws HibernateException {
+        Long seed = (Long) super.generate(session, object);
+        Long m = (long) Math.pow(2, 32);
+        Long a = 22695477L;
+        Long c = 1L;
+
+        return (a * seed + c) % m;
+    }
+}


### PR DESCRIPTION
Zmieniłem sposób generowania ID pokoi. Użyłem *Linear Congruential Generator* do hashowania 1,2,3... na duże liczby. Zakres nie powinien się wyczerpać (2^32).